### PR TITLE
Add optional Express backend for web deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20
+WORKDIR /app
+COPY . .
+RUN npm install --production
+RUN npm run prod-linux
+CMD ["node", "web-server/server.js"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Beta/nightly build available [here](https://vrcx.app/github/nightly) or in-app `
 - Want a new look for VRCX? Check out [Themes](https://github.com/vrcx-team/VRCX/wiki/Themes)
 - See [Building from source](https://github.com/vrcx-team/VRCX/wiki/Building-from-source) for instructions on how to build VRCX from source.
 - For a guide on how to run VRCX on linux, see [here](https://github.com/vrcx-team/VRCX/wiki/Running-VRCX-on-Linux)
+## Web Deployment
+
+To serve VRCX through a standard web browser you can build the frontend and run the Express backend:
+
+```bash
+npm run prod-linux
+node web-server/server.js
+```
+
+Set `VRCX_BACKEND_URL` when building to configure the API base URL and `VRCX_AUTH_TOKEN` to protect the endpoints. A simple `Dockerfile` is provided for container deployments.
+
+When deploying remotely please review VRChat's API policies; see the legal notice below.
+
 
 # Screenshots
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,10 @@
             "name": "VRCX",
             "license": "MIT",
             "dependencies": {
+                "express": "^5.1.0",
                 "hazardous": "^0.3.0",
-                "node-api-dotnet": "^0.9.11"
+                "node-api-dotnet": "^0.9.11",
+                "node-notifier": "^10.0.1"
             },
             "devDependencies": {
                 "@babel/eslint-parser": "^7.27.5",
@@ -2828,6 +2830,49 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.14.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -3345,6 +3390,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/body-parser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.0",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.6.3",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.0",
+                "raw-body": "^3.0.0",
+                "type-is": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3548,6 +3613,15 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/cacache": {
             "version": "16.1.3",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
@@ -3640,7 +3714,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -3648,6 +3721,22 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsite": {
@@ -4107,12 +4196,51 @@
                 "@babel/types": "^7.6.1"
             }
         },
+        "node_modules/content-disposition": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
         },
         "node_modules/copy-webpack-plugin": {
             "version": "13.0.0",
@@ -4312,7 +4440,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -4454,6 +4581,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/detect-libc": {
@@ -4646,7 +4782,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -4681,6 +4816,12 @@
             "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
             "dev": true,
             "license": "0BSD"
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
         },
         "node_modules/ejs": {
             "version": "3.1.10",
@@ -4934,6 +5075,15 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/encoding": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -5010,7 +5160,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -5020,7 +5169,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -5035,7 +5183,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -5162,6 +5309,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -5483,6 +5636,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -5498,6 +5660,69 @@
             "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/express": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+            "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.0",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
@@ -5646,6 +5871,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/finalhandler": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+            "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5737,6 +5979,24 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/fs-extra": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5776,7 +6036,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -5817,7 +6076,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -5842,7 +6100,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -6008,7 +6265,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -6049,6 +6305,12 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
+        "node_modules/growly": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+            "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
+            "license": "MIT"
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6074,7 +6336,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -6109,7 +6370,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -6258,6 +6518,31 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
+        "node_modules/http-errors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/http-errors/node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/http-proxy-agent": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -6341,7 +6626,6 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6477,7 +6761,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/interpret": {
@@ -6510,6 +6793,15 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/is-ci": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -6536,6 +6828,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-expression": {
@@ -6665,6 +6972,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/isbinaryfile": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.4.tgz",
@@ -6681,8 +7000,7 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
         "node_modules/isobject": {
             "version": "3.0.1",
@@ -7206,7 +7524,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -7217,6 +7534,27 @@
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
             "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
             "dev": true
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge-source-map": {
             "version": "1.1.0",
@@ -7471,8 +7809,7 @@
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/nanoid": {
             "version": "3.3.7",
@@ -7983,6 +8320,32 @@
                 "node": ">=18"
             }
         },
+        "node_modules/node-notifier": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+            "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+            "license": "MIT",
+            "dependencies": {
+                "growly": "^1.3.0",
+                "is-wsl": "^2.2.0",
+                "semver": "^7.3.5",
+                "shellwords": "^0.1.1",
+                "uuid": "^8.3.2",
+                "which": "^2.0.2"
+            }
+        },
+        "node_modules/node-notifier/node_modules/semver": {
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.19",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -8068,6 +8431,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -8079,11 +8454,22 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -8241,6 +8627,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/pascal-case": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -8317,6 +8712,15 @@
             "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/pe-library": {
@@ -8660,6 +9064,19 @@
                 "node": ">=10"
             }
         },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -8823,6 +9240,21 @@
                 "node": ">=6"
             }
         },
+        "node_modules/qs": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/quick-lru": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -8843,6 +9275,30 @@
             "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.6.3",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/raw-loader": {
@@ -9189,11 +9645,32 @@
             "license": "BSD-3-Clause",
             "optional": true
         },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/router/node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -9213,7 +9690,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/sanitize-filename": {
@@ -9366,6 +9842,49 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/send": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+            "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "mime-types": "^3.0.1",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/send/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/send/node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/serialize-error": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -9392,6 +9911,21 @@
                 "randombytes": "^2.1.0"
             }
         },
+        "node_modules/serve-static": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+            "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/set-function-length": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -9408,6 +9942,12 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
         },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
@@ -9441,6 +9981,84 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/shellwords": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+            "license": "MIT"
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/signal-exit": {
@@ -9595,6 +10213,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/string_decoder": {
@@ -10001,6 +10628,15 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
         "node_modules/token-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
@@ -10047,6 +10683,41 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/type-is/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/type-is/node_modules/mime-types": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+            "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/typescript": {
@@ -10120,6 +10791,15 @@
                 "node": ">= 0.4.0"
             }
         },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -10189,6 +10869,24 @@
             "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
             "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
             "dev": true
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/verror": {
             "version": "1.10.1",
@@ -10653,7 +11351,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -10854,7 +11551,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "prod-linux": "cross-env PLATFORM=linux webpack --config webpack.config.js --mode production",
         "build-electron": "node ./src-electron/patch-package-version.js && electron-builder --publish never",
         "postbuild-electron": "node ./src-electron/patch-node-api-dotnet.js && node ./src-electron/rename-builds.js",
-        "start-electron": "electron ."
+        "start-electron": "electron .",
+        "start-web": "node web-server/server.js"
     },
     "repository": {
         "type": "git",
@@ -134,7 +135,9 @@
         }
     },
     "dependencies": {
+        "express": "^5.1.0",
         "hazardous": "^0.3.0",
-        "node-api-dotnet": "^0.9.11"
+        "node-api-dotnet": "^0.9.11",
+        "node-notifier": "^10.0.1"
     }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -123,7 +123,7 @@ import {
     getEmojiFileName,
     languageClass
 } from './composables/user/utils';
-import InteropApi from './ipc-electron/interopApi.js';
+import InteropApi from './interopApi.js';
 import * as localizedStrings from './localization/localizedStrings.js';
 
 // util classes

--- a/src/interopApi.js
+++ b/src/interopApi.js
@@ -1,0 +1,6 @@
+import electronInterop from './ipc-electron/interopApi.js';
+import webInterop from './ipc-web/interopApi.js';
+
+const InteropApi = window.interopApi ? electronInterop : webInterop;
+
+export default InteropApi;

--- a/src/ipc-web/interopApi.js
+++ b/src/ipc-web/interopApi.js
@@ -1,0 +1,31 @@
+class WebInteropApi {
+  constructor() {
+    return new Proxy(this, {
+      get(target, prop) {
+        if (typeof prop === 'string' && !target[prop]) {
+          return new Proxy({}, {
+            get(_, methodName) {
+              return async (...args) => {
+                return target.callMethod(prop, methodName, ...args);
+              };
+            }
+          });
+        }
+        return target[prop];
+      }
+    });
+  }
+
+  async callMethod(className, methodName, ...args) {
+    const res = await fetch(`${API_BASE_URL}/api/dotnet`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ className, methodName, args })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Request failed');
+    return data.result;
+  }
+}
+
+export default new WebInteropApi();

--- a/web-server/InteropApi.js
+++ b/web-server/InteropApi.js
@@ -1,0 +1,37 @@
+const dotnet = require('node-api-dotnet/net9.0');
+
+class InteropApi {
+    constructor() {
+        // Cache for .NET objects, might be problematic if we require a new instance every time
+        this.createdObjects = {};
+    }
+
+    getDotNetObject(className) {
+        if (!this.createdObjects[className]) {
+            console.log(`Creating new instance of ${className}`);
+            this.createdObjects[className] = new dotnet.VRCX[className]();
+        }
+        return this.createdObjects[className];
+    }
+
+    callMethod(className, methodName, args) {
+        try {
+            const obj = this.getDotNetObject(className);
+            if (typeof obj[methodName] !== 'function') {
+                throw new Error(
+                    `Method ${methodName} does not exist on class ${className}`
+                );
+            }
+            return obj[methodName](...args);
+        } catch (e) {
+            console.error(
+                'Error calling .NET method',
+                `${className}.${methodName}`,
+                e
+            );
+            throw e;
+        }
+    }
+}
+
+module.exports = InteropApi;

--- a/web-server/server.js
+++ b/web-server/server.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const path = require('path');
+const notifier = require('node-notifier');
+const InteropApi = require('./InteropApi');
+const interopApi = new InteropApi();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const AUTH_TOKEN = process.env.VRCX_AUTH_TOKEN || null;
+
+app.use(express.json());
+
+function authMiddleware(req, res, next) {
+  if (AUTH_TOKEN) {
+    const header = req.get('authorization') || '';
+    const token = header.replace(/^Bearer\s+/i, '');
+    if (token !== AUTH_TOKEN) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  }
+  next();
+}
+
+app.use(authMiddleware);
+
+app.post('/api/dotnet', async (req, res) => {
+  const { className, methodName, args = [] } = req.body || {};
+  try {
+    const result = await interopApi.callMethod(className, methodName, args);
+    res.json({ result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+app.post('/api/window/apply-settings', (req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/api/dialog/openFile', (req, res) => {
+  res.status(501).json({ error: 'Not implemented' });
+});
+
+app.get('/api/dialog/openDirectory', (req, res) => {
+  res.status(501).json({ error: 'Not implemented' });
+});
+
+app.post('/api/notification', (req, res) => {
+  const { title, body, icon } = req.body || {};
+  notifier.notify({ title, message: body, icon });
+  res.json({ ok: true });
+});
+
+app.post('/api/app/restart', () => {
+  process.exit(0);
+});
+
+const staticDir = path.resolve(__dirname, '../build/html');
+app.use(express.static(staticDir));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(staticDir, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,7 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             LINUX: JSON.stringify(process.env.PLATFORM === 'linux'),
+            API_BASE_URL: JSON.stringify(process.env.VRCX_BACKEND_URL || ""),
             WINDOWS: JSON.stringify(process.env.PLATFORM === 'windows')
         }),
         new VueLoaderPlugin(),


### PR DESCRIPTION
## Summary
- implement a standalone Express server to serve the built site and expose the same API used in Electron
- add web IPC adapter and switchable `interopApi` module
- allow configuring backend URL in webpack via `VRCX_BACKEND_URL`
- provide simple Dockerfile and start script
- document running the web server in README

## Testing
- `npm run prod-linux`
- `npm run start-web` *(fails: .NET installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af6e5d034833283fb9cefa183790e