### PR TITLE
Document Express backend limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ npm run prod-linux
 node web-server/server.js
 ```
 
+Note: When running the Express backend the `/api/dialog/openFile` and
+`/api/dialog/openDirectory` routes are currently unimplemented and return
+`501 Not Implemented`.
+
 
 Set `VRCX_BACKEND_URL` when building to configure the API base URL and `VRCX_AUTH_TOKEN` to protect the endpoints. A simple `Dockerfile` is provided for container deployments. If webpack runs out of memory you can export `NODE_OPTIONS=--max_old_space_size=4096` before running the build.
 

--- a/web-server/server.js
+++ b/web-server/server.js
@@ -38,10 +38,12 @@ app.post('/api/window/apply-settings', (req, res) => {
   res.json({ ok: true });
 });
 
+// TODO: Implement file selection in the Express backend
 app.get('/api/dialog/openFile', (req, res) => {
   res.status(501).json({ error: 'Not implemented' });
 });
 
+// TODO: Implement directory selection in the Express backend
 app.get('/api/dialog/openDirectory', (req, res) => {
   res.status(501).json({ error: 'Not implemented' });
 });


### PR DESCRIPTION
## Summary
- note openFile/openDirectory gaps in Express backend
- flag TODOs for dialog routes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b07cd1b688332a480fb8090880927