### PR TITLE
Install .NET runtime in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM node:20
+
+RUN apt-get update && \
+    apt-get install -y dotnet-runtime-9.0 && \
+    rm -rf /var/lib/apt/lists/*
+ENV DOTNET_ROOT=/usr/lib/dotnet
+
 WORKDIR /app
 COPY . .
 


### PR DESCRIPTION
## Summary
- install .NET 9 runtime before npm install in Docker build

## Testing
- `node -v`
- `npm -v`
- `npm run prod-linux` *(fails: cross-env: not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b07c81b5483329390049973143381