### PR TITLE
Update web server deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,28 +62,31 @@ Beta/nightly build available [here](https://vrcx.app/github/nightly) or in-app `
 - For a guide on how to run VRCX on linux, see [here](https://github.com/vrcx-team/VRCX/wiki/Running-VRCX-on-Linux)
 ## Web Deployment
 
-
-To serve VRCX through a standard web browser you can build the frontend and run the Express backend. Ensure Node.js and the .NET runtime are installed and run the following:
+To serve VRCX through a standard web browser you can build the frontend and run
+the Express backend. Ensure Node.js and the .NET 9 runtime are installed:
 
 ```bash
+sudo apt install dotnet-runtime-9.0
 npm install
-
-To serve VRCX through a standard web browser you can build the frontend and run the Express backend:
-
-```bash
-
 npm run prod-linux
-node web-server/server.js
 ```
 
+If the runtime is not installed under `/usr/lib/dotnet`, set `DOTNET_ROOT` to
+the install directory.
 
-Set `VRCX_BACKEND_URL` when building to configure the API base URL and `VRCX_AUTH_TOKEN` to protect the endpoints. A simple `Dockerfile` is provided for container deployments. If webpack runs out of memory you can export `NODE_OPTIONS=--max_old_space_size=4096` before running the build.
+Launch the server with:
 
-Set `VRCX_BACKEND_URL` when building to configure the API base URL and `VRCX_AUTH_TOKEN` to protect the endpoints. A simple `Dockerfile` is provided for container deployments.
+```bash
+npm run start-web
+```
 
+Set `VRCX_BACKEND_URL` when building to configure the API base URL and
+`VRCX_AUTH_TOKEN` to protect the endpoints. A simple `Dockerfile` is provided
+for container deployments. If webpack runs out of memory you can export
+`NODE_OPTIONS=--max_old_space_size=4096` before running the build.
 
-When deploying remotely please review VRChat's API policies; see the legal notice below.
-
+When deploying remotely please review VRChat's API policies; see the legal
+notice below.
 
 # Screenshots
 


### PR DESCRIPTION
## Summary
- update Web Deployment section
  - mention .NET 9 runtime
  - document `DOTNET_ROOT`
  - use `npm run start-web`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b07cab5ac8332ba12901fbcd20c2d