### PR TITLE
Fix wildcard route and add migration guide

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,24 @@
+## Environment Setup
+- Ensure Node.js and npm are installed.
+- Install project dependencies with `npm install`.
+
+## Routing Fixes
+- Replaced wildcard route `*` in `web-server/server.js` with `/*` to avoid "Missing parameter name" errors.
+
+## Core Module Extraction
+- Separate business logic from Electron UI into reusable Node modules.
+
+## HTTP Server Integration
+- Use Express to serve APIs and static files.
+
+## API Endpoint Definitions
+- Implement routes under `/api` for application functions.
+
+## Security Considerations
+- Add authentication middleware using bearer tokens.
+
+## Deployment Pipeline
+- Use Docker for containerization and integrate CI/CD for automated testing and deployment.
+
+FOA: Transform Windows desktop application into a Node.js webserver application.
+

--- a/web-server/server.js
+++ b/web-server/server.js
@@ -60,7 +60,7 @@ app.post('/api/app/restart', () => {
 
 const staticDir = path.resolve(__dirname, '../build/html');
 app.use(express.static(staticDir));
-app.get('*', (req, res) => {
+app.get('/*', (req, res) => {
   res.sendFile(path.join(staticDir, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- update wildcard route to avoid missing parameter name error
- document migration guide in `agent.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b0d7a13e08332962370ea969e715a