### PR TITLE
Fix wildcard route and handle missing dotnet

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,24 @@
+## Environment Setup
+- Ensure Node.js and npm are installed.
+- Install project dependencies with `npm install`.
+
+## Routing Fixes
+- Replaced wildcard route `*` in `web-server/server.js` with `/*splat` to avoid "Missing parameter name" errors.
+
+## Core Module Extraction
+- Separate business logic from Electron UI into reusable Node modules.
+
+## HTTP Server Integration
+- Use Express to serve APIs and static files.
+
+## API Endpoint Definitions
+- Implement routes under `/api` for application functions.
+
+## Security Considerations
+- Add authentication middleware using bearer tokens.
+
+## Deployment Pipeline
+- Use Docker for containerization and integrate CI/CD for automated testing and deployment.
+
+FOA: Transform Windows desktop application into a Node.js webserver application.
+

--- a/web-server/InteropApi.js
+++ b/web-server/InteropApi.js
@@ -1,4 +1,10 @@
-const dotnet = require('node-api-dotnet/net9.0');
+let dotnet = null;
+try {
+    dotnet = require('node-api-dotnet/net9.0');
+} catch (err) {
+    console.error('Failed to load node-api-dotnet:', err);
+    // Allows server to start even if .NET is not installed
+}
 
 class InteropApi {
     constructor() {
@@ -7,6 +13,9 @@ class InteropApi {
     }
 
     getDotNetObject(className) {
+        if (!dotnet) {
+            throw new Error('node-api-dotnet module not available');
+        }
         if (!this.createdObjects[className]) {
             console.log(`Creating new instance of ${className}`);
             this.createdObjects[className] = new dotnet.VRCX[className]();

--- a/web-server/server.js
+++ b/web-server/server.js
@@ -60,7 +60,8 @@ app.post('/api/app/restart', () => {
 
 const staticDir = path.resolve(__dirname, '../build/html');
 app.use(express.static(staticDir));
-app.get('*', (req, res) => {
+// route all other requests to index.html
+app.get('/*splat', (req, res) => {
   res.sendFile(path.join(staticDir, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- handle missing `.NET` runtime in `InteropApi` so server can start without it
- adjust wildcard route pattern to `/*splat`
- keep migration guide in `agent.md` updated

## Testing
- `npm install`
- `npm run start-web` *(shows server starts even without .NET runtime)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b0d7a13e08332962370ea969e715a